### PR TITLE
feat: add GetUserByID method to Client

### DIFF
--- a/apiMethods.go
+++ b/apiMethods.go
@@ -1,0 +1,36 @@
+// Robloxgo - Roblox bindings for Go
+// Available at https://github.com/RhykerWells/robloxgo
+
+// Copyright 2025 Rhyker Wells <a.rhykerw@gmail.com>.  All rights reserved.
+// License can be found in the LICENSE file of the repository.
+
+// Package robloxgo provides Roblox binding for Go
+
+package robloxgo
+
+import (
+	"net/http"
+)
+
+// get is an internal method that makes a GET request to the specified URL
+
+// If the response status code is not 200 (OK/Successful), it 
+// returns a custom error describing the HTTP status code
+func (c *Client) get(methodURL string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodGet, methodURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != ResponseOK.Code {
+		return nil, getFullHttpError(resp.StatusCode)
+	}
+
+	return resp, nil
+}

--- a/endpoints.go
+++ b/endpoints.go
@@ -22,4 +22,5 @@ var (
 	// Cloud APIs
 	EndpointCloud       = "https://apis.roblox.com/cloud/v"
 	EndpointCloudAPI    = EndpointCloud + CloudAPIVersion + "/"
+	EndPointCloudUsers  = EndpointCloudAPI + "users/"
 )

--- a/user.go
+++ b/user.go
@@ -1,0 +1,53 @@
+// Robloxgo - Roblox bindings for Go
+// Available at https://github.com/RhykerWells/robloxgo
+
+// Copyright 2025 Rhyker Wells <a.rhykerw@gmail.com>.  All rights reserved.
+// License can be found in the LICENSE file of the repository.
+
+// Package robloxgo provides Roblox binding for Go
+
+package robloxgo
+
+import (
+	"encoding/json"
+)
+
+// A User stores all data for an individual Roblox user.
+type User struct {
+	// The ID of the user.
+	ID string `json:"id"`
+
+	// The user's username.
+	Username string `json:"name"`
+
+	// The user's display name, if it is set.
+	Displayname string `json:"displayName"`
+
+	// The user's premium status.
+	Premium bool `json:"premium"`
+
+	// The user's chosen language option.
+	Locale string `json:"locale"`
+
+	// The user's account creation date.
+	CreatedAt string `json:"createTime"`
+}
+
+// GetUserByID retrieves a Roblox user from the Open Cloud API by their user ID.
+//
+// Returns an error if the HTTP request fails, if the response body cannot
+// be decoded, or if the user does not exist.
+func (c *Client) GetUserByID(userID string) (*User, error) {
+	response, err := c.get(EndPointCloudUsers + userID)
+	if err != nil {
+		return nil, err
+	}
+
+	user := new(User)
+	err = json.NewDecoder(response.Body).Decode(user)
+	if err != nil {
+		return nil, err
+	}
+
+	return user, nil
+}

--- a/user_test.go
+++ b/user_test.go
@@ -1,0 +1,53 @@
+// Robloxgo - Roblox bindings for Go
+// Available at https://github.com/RhykerWells/robloxgo
+
+// Copyright 2025 Rhyker Wells <a.rhykerw@gmail.com>.  All rights reserved.
+// License can be found in the LICENSE file of the repository.
+
+// Package robloxgo provides Roblox binding for Go
+
+package robloxgo
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGetUser_EmptyUserID(t *testing.T) {
+	apiKey := os.Getenv("RG_APIKEY")
+	client, _ := Create(apiKey)
+
+	user, err := client.GetUserByID("")
+	if err == nil {
+		t.Fatal("expected error for empty userID, got nil")
+	}
+	if user != nil {
+		t.Fatalf("expected nil user, got %v", user)
+	}
+}
+
+func TestGetUser_InvalidUserID(t *testing.T) {
+	apiKey := os.Getenv("RG_APIKEY")
+	client, _ := Create(apiKey)
+
+	user, err := client.GetUserByID("xxx")
+	if err == nil {
+		t.Fatalf("expected error for invalid userID, got %v", err)
+	}
+	if user != nil {
+		t.Fatalf("unexpected user, got %v", user)
+	}
+}
+
+func TestGetUser_PopulatedUserID(t *testing.T) {
+	apiKey := os.Getenv("RG_APIKEY")
+	client, _ := Create(apiKey)
+
+	user, err := client.GetUserByID("520198334")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if user == nil {
+		t.Fatal("expected user, got nil")
+	}
+}


### PR DESCRIPTION
This PR introduces the `User` struct and the `GetUserByID` method to support retrieving Roblox user data via the Open Cloud API.

# Usage
```go
user, err := client.GetUserByID("123456")
if err != nil {
	log.Fatal(err)
}
fmt.Println(user.Username)
```

# Notes
Currently only supports ID-based lookups (OpenCloud limitation)