### PR TITLE
feat: add GetUserByUsername to Client

### DIFF
--- a/apiMethods.go
+++ b/apiMethods.go
@@ -9,15 +9,42 @@
 package robloxgo
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/http"
 )
 
 // get is an internal method that makes a GET request to the specified URL
 
-// If the response status code is not 200 (OK/Successful), it 
+// If the response status code is not 200 (OK/Successful), it
 // returns a custom error describing the HTTP status code
 func (c *Client) get(methodURL string) (*http.Response, error) {
 	req, err := http.NewRequest(http.MethodGet, methodURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != ResponseOK.Code {
+		return nil, getFullHttpError(resp.StatusCode)
+	}
+
+	return resp, nil
+}
+
+// post is an internal method that makes a POST request to the specified URL
+
+// If the response status code is not 200 (OK/Successful), it 
+// returns a custom error describing the HTTP status code
+func (c *Client) post(methodURL string, body any) (*http.Response, error) {
+	var requestBody bytes.Buffer
+    json.NewEncoder(&requestBody).Encode(body)
+	req, err := http.NewRequest(http.MethodPost, methodURL, &requestBody)
 	if err != nil {
 		return nil, err
 	}

--- a/endpoints.go
+++ b/endpoints.go
@@ -23,4 +23,8 @@ var (
 	EndpointCloud       = "https://apis.roblox.com/cloud/v"
 	EndpointCloudAPI    = EndpointCloud + CloudAPIVersion + "/"
 	EndPointCloudUsers  = EndpointCloudAPI + "users/"
+
+	// Legacy APIs
+	EndpointLegacyUsers = "https://users.roblox.com"
+	EndpointLegacyGetUsers = EndpointLegacyUsers + "/v1/usernames/users"
 )

--- a/user.go
+++ b/user.go
@@ -53,6 +53,13 @@ func (c *Client) GetUserByID(userID string) (*User, error) {
 	return user, nil
 }
 
+// GetUserByUsername retrieves a Roblox user from the Legacy Roblox API by their user Username.
+//
+// Returns an error if the HTTP request fails, if the response body cannot
+// be decoded, or if the user does not exist.
+//
+// This method may be deprecated if Roblox removes the 
+// legacy https://users.roblox.com/v1/usernames/users endpoint
 func (c *Client) GetUserByUsername(username string) (*User, error) {
 	if username == "" {
 		return nil, errors.New("no username")

--- a/user_test.go
+++ b/user_test.go
@@ -51,3 +51,43 @@ func TestGetUser_PopulatedUserID(t *testing.T) {
 		t.Fatal("expected user, got nil")
 	}
 }
+
+
+func TestGetUser_EmptyUsername(t *testing.T) {
+	apiKey := os.Getenv("RG_APIKEY")
+	client, _ := Create(apiKey)
+
+	user, err := client.GetUserByUsername("")
+	if err == nil {
+		t.Fatal("expected error for empty username, got nil")
+	}
+	if user != nil {
+		t.Fatalf("expected nil user, got %v", user)
+	}
+}
+
+func TestGetUser_InvalidUsername(t *testing.T) {
+	apiKey := os.Getenv("RG_APIKEY")
+	client, _ := Create(apiKey)
+
+	user, err := client.GetUserByUsername("xxx")
+	if err == nil {
+		t.Fatal("expected error for invalid username, got nil")
+	}
+	if user != nil {
+		t.Fatalf("expected nil user, got %v", user)
+	}
+}
+
+func TestGetUser_PopulatedUsername(t *testing.T) {
+	apiKey := os.Getenv("RG_APIKEY")
+	client, _ := Create(apiKey)
+
+	user, err := client.GetUserByUsername("captainbarborsa")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if user == nil {
+		t.Fatal("expected user, got nil")
+	}
+}


### PR DESCRIPTION
This PR builds off of the previous (#1), and implements `GetUserByUsername` which calls the legacy `https://users.roblox.com/v1/usernames/users` endpoint

# Usage
```go
user, err := client.GetUserByUsername("123456")
if err != nil {
	log.Fatal(err)
}
fmt.Println(user.Username)
```

# Notes
If Roblox ever deprecates the endpoint, this will be deprecated. Unless OpenCloud implements searching via usernames