### PR TITLE
feat: add GetThumbnailURI to User

### DIFF
--- a/user.go
+++ b/user.go
@@ -111,3 +111,28 @@ func (c *Client) GetUserByUsername(username string) (*User, error) {
 
 	return user, nil
 }
+
+// ThumbnailURI retrieves a Roblox user's thumbnail URI from the Open Cloud API.
+//
+// Returns an error if the HTTP request fails, or if the response body cannot
+// be decoded.
+func (u *User) GetUserThumbnailURI(queryParams ...queryParam) (string, error) {
+	methodURL := EndPointCloudUsers + u.ID.String() + ":generateThumbnail"
+	response, err := u.Client.get(methodURL, queryParams...)
+	if err != nil {
+		return "", err
+	}
+
+	var thumbnailResponse struct {
+		Response struct {
+			Type     string `json:"@type"`
+			ImageURI string `json:"imageUri"`
+		} `json:"response"`
+	}
+	err = json.NewDecoder(response.Body).Decode(&thumbnailResponse)
+	if err != nil {
+		return "", err
+	}
+
+	return thumbnailResponse.Response.ImageURI, nil
+}

--- a/user_test.go
+++ b/user_test.go
@@ -89,3 +89,24 @@ func TestGetUser_PopulatedUsername(t *testing.T) {
 		t.Fatal("expected user, got nil")
 	}
 }
+
+func TestGetUserThumnail(t *testing.T) {
+	apiKey := os.Getenv("RG_APIKEY")
+	client, _ := Create(apiKey)
+
+	user, err := client.GetUserByID("369780411")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if user == nil {
+		t.Fatal("expected user, got nil")
+	}
+
+	uri, err := user.GetUserThumbnailURI()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if uri == "" {
+		t.Fatal("expected user, got nil")
+	}
+}


### PR DESCRIPTION
This PR builds off of the previous, and implements `GetThumbnailURI` which returns the full URI of a given user's thumbnail

# Usage
```go
uri, err := user.GetThumnailURI()
if err != nil {
	log.Fatal(err)
}
fmt.Println(uri)
```

# Notes
The endpoint supports 3 query parameters:
- `format`:
  - Valid values are `PNG` (DEFAULT) & `JPEG`
- `shape`:
  - Valid values are `ROUND` (DEFAULT), `SQUARE`
- `size`:
  - Valid values are `48`, `50`, `60`, `75`, `100`, `110`, `150`, `180`, `352`, `420` (DEFAULT), `720`